### PR TITLE
Change ITALIC markdown from '_content_' to '*content*'

### DIFF
--- a/src/stateToMarkdown.js
+++ b/src/stateToMarkdown.js
@@ -208,7 +208,7 @@ class MarkupGenerator {
           content = `++${content}++`;
         }
         if (style.has(ITALIC)) {
-          content = `_${content}_`;
+          content = `*${content}*`;
         }
         if (style.has(STRIKETHROUGH)) {
           // TODO: encode `~`?


### PR DESCRIPTION
Tried many markdown editor "xxx_content_xxx" syntax will not make content italic. 
change "_" to "*" works fine